### PR TITLE
Fix saving background and foreground color issue

### DIFF
--- a/schemer/schemer.py
+++ b/schemer/schemer.py
@@ -566,12 +566,12 @@ class GUI:
     if data == self.colorbuttonBackground:
       color = data.get_color()
       self.dictAllStyles[self.selectedStyleId].background = ('#%02x%02x%02x' %
-        (color.red * cScale, color.green * cScale, color.blue * cScale))
+        (int(round(color.red * cScale)), int(round(color.green * cScale)), int(round(color.blue * cScale))))
     
     elif data == self.colorbuttonForeground:
       color = data.get_color()
       self.dictAllStyles[self.selectedStyleId].foreground = ('#%02x%02x%02x' %
-        (color.red * cScale, color.green * cScale, color.blue * cScale))
+        (int(round(color.red * cScale)), int(round(color.green * cScale)), int(round(color.blue * cScale))))
     
     elif data == self.togglebuttonBold:
       self.dictAllStyles[self.selectedStyleId].bold = data.get_active()


### PR DESCRIPTION
I encountered the following problem when using Color Theme Editor:

```
Traceback (most recent call last):
  File "/usr/lib/x86_64-linux-gnu/gedit/plugins/colorschemer/schemer.py", line 569, in on_style_changed
    (color.red * cScale, color.green * cScale, color.blue * cScale))
TypeError: %x format: an integer is required, not float
```

I think this change will fix the problem.
